### PR TITLE
fix: scope mDNS announcements to outgoing interfaces

### DIFF
--- a/docs/issues/299/mdns-interface-routing-investigation-report.md
+++ b/docs/issues/299/mdns-interface-routing-investigation-report.md
@@ -113,11 +113,11 @@ The fixed F-Droid debug APK was installed over the same debug-only package on th
 
 The fixed APK was also installed on a dedicated Android 12/API 31 x86_64 emulator. The app cold-launched successfully, remained stable after backgrounding, and its forwarded HTTP endpoint returned `200` both before and after backgrounding. The mDNS responder started and announced on the emulator's eligible interfaces. Stock emulator NAT did not carry guest multicast to the host, so host-side `.local` resolution was not treated as a product pass or failure.
 
-`git diff --check` also passes. CI remains pending.
+`git diff --check` also passes. GitHub registered no CI checks for pull request #348 at report-posting time.
 
 ## Remaining limitations
 
 - The baseline failure has been reproduced on one physical Android device and Linux resolver topology.
 - Android 12 runtime and direct-network compatibility were validated, but stock emulator NAT prevented end-to-end host-LAN multicast validation.
 - Windows and phone-hotspot validation have not yet been performed.
-- CI status is pending for pull request #348.
+- No GitHub CI checks were registered for pull request #348 at report-posting time.

--- a/docs/issues/299/mdns-interface-routing-investigation-report.md
+++ b/docs/issues/299/mdns-interface-routing-investigation-report.md
@@ -1,0 +1,121 @@
+# mDNS announcements publish an unreachable interface address
+
+## Tracking
+
+- Issue: https://github.com/plainhub/plain-app/issues/299
+- Repository: https://github.com/plainhub/plain-app
+- Branch/commit tested: `upstream/main` at `43eebc1c3dc88328c27363c8dd01c12b6fbfd898`
+- Pull request: pending
+
+## Priority and scope
+
+This issue was selected because it affects the primary connection path to PlainApp, has reports from multiple users, and remains reproducible on current upstream code. It is older and more broadly applicable than the other leading open bug candidates that require unavailable vendor-specific hardware or media samples.
+
+The investigation covers PlainApp's Android mDNS host responder and Linux `.local` resolution. Note/Markdown-editor work and unrelated discovery or server lifecycle changes are explicitly out of scope.
+
+## Reported behavior
+
+Users report that the configured `*.local` PlainApp address does not resolve or connect, while access through the phone's numeric LAN address continues to work. The issue discussion includes failures on Linux and Windows and across Wi-Fi and hotspot configurations.
+
+## Reproduction
+
+### Environment
+
+- PlainApp F-Droid debug build `3.3.10` (`661`)
+- Clean `upstream/main` worktree at `43eebc1c3dc88328c27363c8dd01c12b6fbfd898`
+- Pixel 9 Pro running GrapheneOS/Android 17 (API 37)
+- Linux host using Avahi and `mdns4_minimal` name-service resolution
+- Phone connected over Wi-Fi with an active VPN tunnel interface
+- PlainApp HTTP service on port `8180`
+
+Device identifiers, the configured hostname, and network addresses are intentionally omitted.
+
+### Steps
+
+1. Build and install the clean upstream F-Droid debug APK.
+2. Start PlainApp's web server and mDNS responder while both the Wi-Fi and VPN tunnel interfaces are active.
+3. Confirm that the numeric Wi-Fi URL responds over HTTP.
+4. Resolve the configured `.local` hostname through the Linux system resolver and attempt the same HTTP request through that hostname.
+5. Send a direct unicast-response-requested mDNS A query to the phone and inspect the returned A record.
+
+### Actual result
+
+- The numeric Wi-Fi URL returns HTTP `200`.
+- The system resolver caches exactly one IPv4 address for the `.local` name: the phone's VPN tunnel address.
+- The resolver does not return the phone's Wi-Fi address, and the `.local` HTTP request fails.
+- A direct mDNS query reaches the phone and receives one A record containing the correct Wi-Fi address.
+
+The responder is therefore alive and reachable on Wi-Fi, but its unsolicited announcement poisons the neighbor's cache with an address that is not reachable from that Wi-Fi segment.
+
+### Expected result
+
+An mDNS announcement sent on an interface must advertise the address reachable through that interface. A Wi-Fi listener should resolve the PlainApp hostname to the phone's Wi-Fi address, and the `.local` URL should reach the same server as the numeric Wi-Fi URL.
+
+## Investigation findings
+
+In the reproduced baseline, `candidateInterfaces()` accepted every active, non-loopback IPv4 interface except interfaces whose names matched the mobile-data list. This included a point-to-point VPN interface such as `tun0`.
+
+The baseline `MdnsHostResponder.broadcastService()` then collected the addresses of all candidate interfaces into one announcement packet and sent that identical packet through every candidate interface. Consequently, the packet sent on Wi-Fi could advertise an address owned by an unrelated VPN interface.
+
+The query-response path is interface-scoped: `respondToPacket()` answers with the local address on which the query arrived. This explains why the direct query returns the correct Wi-Fi address while the system resolver, which already accepted the gratuitous announcement, retains the unreachable tunnel address.
+
+The following alternatives were ruled out during reproduction:
+
+- HTTP server failure: the numeric Wi-Fi URL returned `200`.
+- Missing Linux mDNS support: Avahi was active and the host was configured for `.local` resolution.
+- Responder startup or receive failure: the direct query received an answer from the phone.
+- A stale released build: the failure was reproduced from a clean current-upstream build.
+
+## Root cause
+
+The mDNS interface selection admits point-to-point/non-multicast tunnel interfaces, and the gratuitous announcement path combines addresses from all selected interfaces into a single response sent on every interface. This leaks an unreachable VPN address into the Wi-Fi mDNS scope and allows it to replace the usable Wi-Fi address in a resolver cache.
+
+## Implemented correction
+
+The Android interface enumerator now requires an interface to be active, non-loopback, non-point-to-point, multicast-capable, and outside the existing mobile-data name list. Capability reads are best-effort; an interface whose properties cannot be read is not admitted into discovery.
+
+`MdnsHostResponder.broadcastService()` now builds a separate packet for each outgoing interface. Both service announcements and hostname-only announcements contain exactly one A record: the address belonging to that outgoing interface. A Wi-Fi announcement can therefore no longer publish a VPN or unrelated LAN address.
+
+The iOS interface provider was not changed. Valid Android Wi-Fi/hotspot multicast interfaces remain eligible, while point-to-point tunnels and interfaces that cannot carry multicast are excluded.
+
+## Regression coverage
+
+- `MdnsIfaceSelectorTest` proves that an active multicast-capable Wi-Fi interface remains eligible and that point-to-point, non-multicast, and mobile-data interfaces are rejected.
+- `MdnsAnnouncementTest` proves that service and hostname-only announcements contain only their outgoing interface address, even when the source service information also contains a tunnel address.
+- The complete `shared-lib` Android host suite passes: 90 tests, 0 failures, 0 errors, 0 skipped.
+
+## Validation
+
+Baseline build completed successfully:
+
+```text
+PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH ./gradlew :app:assembleFdroidDebug
+BUILD SUCCESSFUL
+```
+
+Implementation validation completed successfully:
+
+```text
+./gradlew :shared-lib:testAndroidHostTest
+90 tests, 0 failures, 0 errors, 0 skipped
+
+PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH ./gradlew :app:assembleFdroidDebug
+BUILD SUCCESSFUL
+
+PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH ./gradlew :app:assembleDebug
+BUILD SUCCESSFUL
+```
+
+The fixed F-Droid debug APK was installed over the same debug-only package on the physical phone; the release package was not modified. With the same Wi-Fi and VPN interfaces active:
+
+- Before: the resolver returned only the tunnel address; numeric HTTP returned `200`; `.local` HTTP failed.
+- After: the resolver returned only the Wi-Fi address; both numeric and `.local` HTTP returned `200`.
+
+`git diff --check` also passes. CI and Android 12 emulator results remain pending.
+
+## Remaining limitations
+
+- The baseline failure has been reproduced on one physical Android device and Linux resolver topology.
+- Android 12 emulator coverage is being prepared separately; emulator NAT may prevent meaningful host-LAN multicast validation.
+- Windows and phone-hotspot validation have not yet been performed.
+- CI status and pull-request links will be added after implementation.

--- a/docs/issues/299/mdns-interface-routing-investigation-report.md
+++ b/docs/issues/299/mdns-interface-routing-investigation-report.md
@@ -111,11 +111,13 @@ The fixed F-Droid debug APK was installed over the same debug-only package on th
 - Before: the resolver returned only the tunnel address; numeric HTTP returned `200`; `.local` HTTP failed.
 - After: the resolver returned only the Wi-Fi address; both numeric and `.local` HTTP returned `200`.
 
-`git diff --check` also passes. CI and Android 12 emulator results remain pending.
+The fixed APK was also installed on a dedicated Android 12/API 31 x86_64 emulator. The app cold-launched successfully, remained stable after backgrounding, and its forwarded HTTP endpoint returned `200` both before and after backgrounding. The mDNS responder started and announced on the emulator's eligible interfaces. Stock emulator NAT did not carry guest multicast to the host, so host-side `.local` resolution was not treated as a product pass or failure.
+
+`git diff --check` also passes. CI remains pending.
 
 ## Remaining limitations
 
 - The baseline failure has been reproduced on one physical Android device and Linux resolver topology.
-- Android 12 emulator coverage is being prepared separately; emulator NAT may prevent meaningful host-LAN multicast validation.
+- Android 12 runtime and direct-network compatibility were validated, but stock emulator NAT prevented end-to-end host-LAN multicast validation.
 - Windows and phone-hotspot validation have not yet been performed.
-- CI status and pull-request links will be added after implementation.
+- CI status and pull-request links will be added after pull-request creation.

--- a/docs/issues/299/mdns-interface-routing-investigation-report.md
+++ b/docs/issues/299/mdns-interface-routing-investigation-report.md
@@ -5,7 +5,7 @@
 - Issue: https://github.com/plainhub/plain-app/issues/299
 - Repository: https://github.com/plainhub/plain-app
 - Branch/commit tested: `upstream/main` at `43eebc1c3dc88328c27363c8dd01c12b6fbfd898`
-- Pull request: pending
+- Pull request: https://github.com/plainhub/plain-app/pull/348
 
 ## Priority and scope
 
@@ -120,4 +120,4 @@ The fixed APK was also installed on a dedicated Android 12/API 31 x86_64 emulato
 - The baseline failure has been reproduced on one physical Android device and Linux resolver topology.
 - Android 12 runtime and direct-network compatibility were validated, but stock emulator NAT prevented end-to-end host-LAN multicast validation.
 - Windows and phone-hotspot validation have not yet been performed.
-- CI status and pull-request links will be added after pull-request creation.
+- CI status is pending for pull request #348.

--- a/shared-lib/src/androidHostTest/kotlin/com/ismartcoding/plain/lib/mdns/MdnsAnnouncementTest.kt
+++ b/shared-lib/src/androidHostTest/kotlin/com/ismartcoding/plain/lib/mdns/MdnsAnnouncementTest.kt
@@ -1,0 +1,34 @@
+package com.ismartcoding.plain.lib.mdns
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MdnsAnnouncementTest {
+
+    @Test fun `service announcement contains only its outgoing interface address`() {
+        val wifiIp = "192.168.1.55"
+        val service = MdnsServiceInfo(
+            instanceName = "PlainApp",
+            serviceType = PLAINAPP_SERVICE_TYPE,
+            targetHostname = "plainapp.local",
+            port = 8080,
+            txtRecords = emptyList(),
+            ips = listOf(wifiIp, "10.8.0.2"),
+        )
+
+        val bytes = MdnsHostResponder.buildAnnouncement(service, "plainapp.local", wifiIp)
+
+        assertEquals(listOf(wifiIp), advertisedAddresses(bytes!!))
+    }
+
+    @Test fun `hostname announcement contains only its outgoing interface address`() {
+        val wifiIp = "192.168.1.55"
+
+        val bytes = MdnsHostResponder.buildAnnouncement(null, "plainapp.local", wifiIp)
+
+        assertEquals(listOf(wifiIp), advertisedAddresses(bytes!!))
+    }
+
+    private fun advertisedAddresses(bytes: ByteArray): List<String> =
+        MdnsPacketCodec.parseResponse(bytes)?.allRecords?.mapNotNull { it.ip }.orEmpty()
+}

--- a/shared-lib/src/androidHostTest/kotlin/com/ismartcoding/plain/lib/mdns/MdnsIfaceSelectorTest.kt
+++ b/shared-lib/src/androidHostTest/kotlin/com/ismartcoding/plain/lib/mdns/MdnsIfaceSelectorTest.kt
@@ -3,6 +3,7 @@ package com.ismartcoding.plain.lib.mdns
 import com.ismartcoding.plain.lib.mdns.ipToInt
 import com.ismartcoding.plain.lib.mdns.isMobileDataInterface
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.net.DatagramPacket
@@ -63,6 +64,20 @@ class MdnsIfaceSelectorTest {
 
     @Test fun `dummy0 is not mobile data`() = assertTrue(!isMobileDataInterface("dummy0"))
     @Test fun `v4-wlan0 is not mobile data`() = assertTrue(!isMobileDataInterface("v4-wlan0"))
+
+    // ── isMdnsInterfaceEligible ─────────────────────────────────────────────
+
+    @Test fun `active multicast wifi interface is eligible`() =
+        assertTrue(isMdnsInterfaceEligible("wlan0", true, false, false, true))
+
+    @Test fun `point to point tunnel interface is not eligible`() =
+        assertFalse(isMdnsInterfaceEligible("tun0", true, false, true, true))
+
+    @Test fun `interface without multicast support is not eligible`() =
+        assertFalse(isMdnsInterfaceEligible("dummy0", true, false, false, false))
+
+    @Test fun `mobile data interface is not eligible`() =
+        assertFalse(isMdnsInterfaceEligible("rmnet_data0", true, false, false, true))
 
     // ── helpers ───────────────────────────────────────────────────────────────
 

--- a/shared-lib/src/androidMain/kotlin/com/ismartcoding/plain/lib/mdns/MdnsPlatform.android.kt
+++ b/shared-lib/src/androidMain/kotlin/com/ismartcoding/plain/lib/mdns/MdnsPlatform.android.kt
@@ -16,8 +16,17 @@ internal actual fun createMdnsSocket(): MdnsSocket = JvmMdnsSocket()
 internal actual fun candidateInterfaces(): List<Pair<MdnsIface, String>> =
     runCatching {
         NetworkInterface.getNetworkInterfaces()?.asSequence()
-            ?.filter { it.isUp && !it.isLoopback }
-            ?.filterNot { isMobileDataInterface(it.name) }
+            ?.filter { iface ->
+                runCatching {
+                    isMdnsInterfaceEligible(
+                        name = iface.name,
+                        isUp = iface.isUp,
+                        isLoopback = iface.isLoopback,
+                        isPointToPoint = iface.isPointToPoint,
+                        supportsMulticast = iface.supportsMulticast(),
+                    )
+                }.getOrDefault(false)
+            }
             ?.mapNotNull { iface ->
                 val ip = iface.inetAddresses.asSequence()
                     .filterIsInstance<Inet4Address>()

--- a/shared-lib/src/commonMain/kotlin/com/ismartcoding/plain/lib/mdns/MdnsHostResponder.kt
+++ b/shared-lib/src/commonMain/kotlin/com/ismartcoding/plain/lib/mdns/MdnsHostResponder.kt
@@ -265,30 +265,31 @@ object MdnsHostResponder {
         val info = serviceInfo
         val candidates = candidateInterfaces()
         if (candidates.isEmpty()) return
-        val ips = candidates.map { it.second }.filter { it.isNotEmpty() }
-        if (ips.isEmpty()) return
+        log("announce ${info?.serviceType ?: hostname} -> $MDNS_GROUP:$MDNS_PORT on ${candidates.size} iface(s)")
+        candidates.forEach { (iface, ip) ->
+            val announcement = buildAnnouncement(info, hostname, ip) ?: return@forEach
+            MdnsPacketCapture.recordOut(ip, MDNS_PORT, MDNS_GROUP, MDNS_PORT, announcement)
+            runCatching {
+                s.setOutgoingInterface(iface.name)
+                s.send(announcement, MDNS_GROUP, MDNS_PORT)
+            }
+        }
+    }
 
-        val announcement = if (info != null) {
+    /** Builds an announcement containing only the address reachable on its outgoing interface. */
+    internal fun buildAnnouncement(info: MdnsServiceInfo?, hostname: String, ip: String): ByteArray? {
+        if (ip.isEmpty()) return null
+        return if (info != null) {
             MdnsServiceResponseBuilder.buildResponseIfMatch(
                 MdnsPacketCodec.buildPtrQuery(info.serviceType),
-                info.copy(ips = ips),
+                info.copy(ips = listOf(ip)),
             )?.bytes
         } else {
             MdnsPacketCodec.buildResponseIfMatch(
                 MdnsPacketCodec.buildQuery(hostname, MdnsPacketCodec.TYPE_A),
                 hostname,
-                ips,
+                listOf(ip),
             )
-        } ?: return
-
-        log("announce ${info?.serviceType ?: hostname} -> $MDNS_GROUP:$MDNS_PORT on ${candidates.size} iface(s)")
-        val srcIp = candidates.first().second
-        MdnsPacketCapture.recordOut(srcIp, MDNS_PORT, MDNS_GROUP, MDNS_PORT, announcement)
-        candidates.forEach { (iface, _) ->
-            runCatching {
-                s.setOutgoingInterface(iface.name)
-                s.send(announcement, MDNS_GROUP, MDNS_PORT)
-            }
         }
     }
 

--- a/shared-lib/src/commonMain/kotlin/com/ismartcoding/plain/lib/mdns/MdnsIfaceSelector.kt
+++ b/shared-lib/src/commonMain/kotlin/com/ismartcoding/plain/lib/mdns/MdnsIfaceSelector.kt
@@ -1,8 +1,8 @@
 package com.ismartcoding.plain.lib.mdns
 
 /**
- * Collects candidate LAN (non-loopback, non-mobile-data) interfaces with their
- * primary IPv4 address string. Platform-specific: java.net on Android, getifaddrs on iOS.
+ * Collects candidate LAN interfaces with their primary IPv4 address string.
+ * Platform-specific: java.net on Android, getifaddrs on iOS.
  */
 internal expect fun candidateInterfaces(): List<Pair<MdnsIface, String>>
 
@@ -24,6 +24,17 @@ fun isMobileDataInterface(name: String): Boolean =
     name.startsWith("rmnet") || name.startsWith("ccmni") ||
         name.startsWith("v4-rmnet") || name.startsWith("v6-rmnet") ||
         name.startsWith("clat") || name.startsWith("v4-ccmni")
+
+/** Whether an Android network interface can carry LAN multicast discovery. */
+internal fun isMdnsInterfaceEligible(
+    name: String,
+    isUp: Boolean,
+    isLoopback: Boolean,
+    isPointToPoint: Boolean,
+    supportsMulticast: Boolean,
+): Boolean =
+    isUp && !isLoopback && !isPointToPoint && supportsMulticast &&
+        !isMobileDataInterface(name)
 
 /** Finds the interface whose subnet contains [senderIp]; falls back to first candidate. */
 internal fun findResponseIface(


### PR DESCRIPTION
## Summary

- reject point-to-point, non-multicast, and mobile-data interfaces from Android LAN mDNS discovery
- build each gratuitous mDNS announcement with only the address of its outgoing interface
- add regression coverage for interface eligibility and both service/hostname announcement paths
- include the complete investigation report at `docs/issues/299/mdns-interface-routing-investigation-report.md`

## Reproduction and result

On clean current upstream code, a physical phone with Wi-Fi and a VPN tunnel active announced both interface addresses on Wi-Fi. The Linux resolver retained only the unreachable tunnel address: numeric HTTP returned 200, while the `.local` request failed. A direct mDNS query still returned the correct Wi-Fi address, isolating the failure to unsolicited announcement scoping.

With this branch installed on the same phone and network, the resolver retained only the Wi-Fi address and both numeric and `.local` HTTP returned 200.

## Validation

- `./gradlew :shared-lib:testAndroidHostTest` — 90 tests passed
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH ./gradlew :app:assembleFdroidDebug` — passed
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH ./gradlew :app:assembleDebug` — passed
- physical GrapheneOS/Android 17 device with simultaneous Wi-Fi and VPN — before/after failure resolved
- Android 12/API 31 x86_64 emulator — cold launch, background stability, mDNS startup, and forwarded HTTP 200 passed; stock emulator NAT does not bridge host-LAN multicast
- `git diff --check` — passed

Fixes #299
