### PR TITLE
feat: add moveMediaItems GraphQL mutation for bulk-moving media into a folder

### DIFF
--- a/shared/apitest/schema.graphqls
+++ b/shared/apitest/schema.graphqls
@@ -158,6 +158,7 @@ type Mutation {
   deleteMediaItems(type: DataType!, query: String!): ActionResult!
   trashMediaItems(type: DataType!, query: String!): ActionResult!
   restoreMediaItems(type: DataType!, query: String!): ActionResult!
+  moveMediaItems(type: DataType!, query: String!, destDir: String!): ActionResult!
   setTempValue(key: String!, value: String!): TempValue!
   relaunchApp: Boolean!
   openAccessibilitySettings: Boolean!

--- a/shared/src/androidMain/kotlin/com/ismartcoding/plain/features/media/BaseMediaContentHelper.kt
+++ b/shared/src/androidMain/kotlin/com/ismartcoding/plain/features/media/BaseMediaContentHelper.kt
@@ -17,10 +17,13 @@ import com.ismartcoding.plain.lib.extensions.getPagingCursor
 import com.ismartcoding.plain.lib.extensions.getSearchCursor
 import com.ismartcoding.plain.lib.extensions.getStringValue
 import com.ismartcoding.plain.lib.extensions.map
+import com.ismartcoding.plain.lib.extensions.scanFileByConnection
 import com.ismartcoding.plain.lib.extensions.toSortName
 import com.ismartcoding.plain.lib.withIO
 import com.ismartcoding.plain.helpers.FilterField
 import com.ismartcoding.plain.lib.logcat.LogCat
+import com.ismartcoding.plain.platform.getNewPath
+import com.ismartcoding.plain.platform.moveFileOrDir
 import com.ismartcoding.plain.data.DMediaBucket
 import com.ismartcoding.plain.enums.MediaType
 import com.ismartcoding.plain.helpers.QueryHelper
@@ -173,6 +176,48 @@ abstract class BaseMediaContentHelper {
         }
 
         return paths
+    }
+
+    /**
+     * Move media files identified by [ids] into the directory [destDir].
+     * The destination directory is created if missing; files already in [destDir]
+     * are skipped. After each successful move, the old and new paths are scanned
+     * so MediaStore picks up the change. Returns true when all items moved.
+     */
+    suspend fun moveByIdsAsync(
+        context: Context,
+        ids: Set<String>,
+        destDir: String,
+    ): Boolean = withIO {
+        val dest = File(destDir)
+        if (!dest.isDirectory && !dest.mkdirs()) {
+            LogCat.w("Failed to create destination directory: $destDir")
+            return@withIO false
+        }
+        var allOk = true
+        val projection = arrayOf(BaseColumns._ID, MediaStore.MediaColumns.DATA)
+        ids.chunked(500).forEach { chunk ->
+            val where = ContentWhere()
+            where.addIn(BaseColumns._ID, chunk)
+            context.contentResolver.getSearchCursor(uriExternal, projection, where)?.forEach { cursor, cache ->
+                val id = cursor.getStringValue(BaseColumns._ID, cache)
+                val path = cursor.getStringValue(MediaStore.MediaColumns.DATA, cache)
+                val src = File(path)
+                if (!src.isFile || src.parentFile == dest) {
+                    return@forEach
+                }
+                val target = File(dest, src.name)
+                val finalPath = if (target.exists()) getNewPath(target.absolutePath) else target.absolutePath
+                if (moveFileOrDir(src.absolutePath, finalPath)) {
+                    context.scanFileByConnection(path)
+                    context.scanFileByConnection(finalPath)
+                } else {
+                    allOk = false
+                    LogCat.w("Failed to move media id=$id to $destDir")
+                }
+            } ?: run { allOk = false }
+        }
+        allOk
     }
 
     @RequiresApi(Build.VERSION_CODES.R)

--- a/shared/src/androidMain/kotlin/com/ismartcoding/plain/platform/MediaStore.android.kt
+++ b/shared/src/androidMain/kotlin/com/ismartcoding/plain/platform/MediaStore.android.kt
@@ -157,6 +157,16 @@ actual suspend fun deleteMedia(dataType: DataType, ids: Set<String>, fromTrash: 
     }
 }
 
+actual suspend fun moveMedia(dataType: DataType, ids: Set<String>, destDir: String): Boolean {
+    return when (dataType) {
+        DataType.AUDIO -> AudioMediaStoreHelper.moveByIdsAsync(appContext, ids, destDir)
+        DataType.DOC -> DocMediaStoreHelper.moveByIdsAsync(appContext, ids, destDir)
+        DataType.IMAGE -> ImageMediaStoreHelper.moveByIdsAsync(appContext, ids, destDir)
+        DataType.VIDEO -> VideoMediaStoreHelper.moveByIdsAsync(appContext, ids, destDir)
+        else -> false
+    }
+}
+
 actual suspend fun getDocExtGroups(query: String): List<Pair<String, Int>> =
     DocMediaStoreHelper.getDocExtGroupsAsync(appContext, query)
 

--- a/shared/src/commonMain/kotlin/com/ismartcoding/plain/httpserver/mainschemas/MediaGraphQL.kt
+++ b/shared/src/commonMain/kotlin/com/ismartcoding/plain/httpserver/mainschemas/MediaGraphQL.kt
@@ -8,6 +8,7 @@ import com.ismartcoding.plain.enums.AppFeatureType
 import com.ismartcoding.plain.enums.DataType
 import com.ismartcoding.plain.enums.has
 import com.ismartcoding.plain.platform.Permission
+import com.ismartcoding.plain.platform.checkEnabledAsync
 import com.ismartcoding.plain.features.TagHelper
 import com.ismartcoding.plain.platform.enabledAndIsGrantedAsync
 import com.ismartcoding.plain.platform.deleteMedia
@@ -18,6 +19,8 @@ import com.ismartcoding.plain.platform.getTrashedMediaIds
 import com.ismartcoding.plain.platform.restoreMedia
 import com.ismartcoding.plain.platform.trashMedia
 import com.ismartcoding.plain.platform.enqueueRemoveImageIndex
+import com.ismartcoding.plain.platform.moveMedia
+import com.ismartcoding.plain.helpers.FilePathValidator
 import com.ismartcoding.plain.preferences.AudioPlaylistPreference
 import com.ismartcoding.plain.preferences.VideoPlaylistPreference
 import com.ismartcoding.plain.httpserver.models.ActionResult
@@ -90,6 +93,21 @@ suspend fun restoreMediaItems(type: DataType, query: String): ActionResult {
         enqueueRemoveImageIndex(ids)
     }
     restoreMedia(type, ids)
+    return ActionResult(type, query)
+}
+
+@GraphQLMutation
+suspend fun moveMediaItems(type: DataType, query: String, destDir: String): ActionResult {
+    Permission.WRITE_EXTERNAL_STORAGE.checkEnabledAsync()
+    FilePathValidator.requireAllSafe(listOf(destDir))
+    val ids = getMediaIds(type, query)
+    if (ids.isEmpty()) {
+        return ActionResult(type, query)
+    }
+    if (type == DataType.IMAGE) {
+        enqueueRemoveImageIndex(ids)
+    }
+    moveMedia(type, ids, destDir)
     return ActionResult(type, query)
 }
 

--- a/shared/src/commonMain/kotlin/com/ismartcoding/plain/platform/MediaStore.kt
+++ b/shared/src/commonMain/kotlin/com/ismartcoding/plain/platform/MediaStore.kt
@@ -47,6 +47,13 @@ expect suspend fun restoreMedia(dataType: DataType, ids: Set<String>)
 expect suspend fun deleteMedia(dataType: DataType, ids: Set<String>, fromTrash: Boolean)
 
 /**
+ * Move media files of [dataType] identified by [ids] into the directory [destDir].
+ * Returns true when all items were moved successfully. Returns false on
+ * platforms without a media store (iOS).
+ */
+expect suspend fun moveMedia(dataType: DataType, ids: Set<String>, destDir: String): Boolean
+
+/**
  * Returns file-extension groups for documents matching [query].
  * Each pair is (extension, count). Returns an empty list on unsupported platforms.
  */

--- a/shared/src/iosMain/kotlin/com/ismartcoding/plain/platform/MediaStore.ios.kt
+++ b/shared/src/iosMain/kotlin/com/ismartcoding/plain/platform/MediaStore.ios.kt
@@ -27,6 +27,8 @@ actual suspend fun restoreMedia(dataType: DataType, ids: Set<String>) {}
 
 actual suspend fun deleteMedia(dataType: DataType, ids: Set<String>, fromTrash: Boolean) {}
 
+actual suspend fun moveMedia(dataType: DataType, ids: Set<String>, destDir: String): Boolean = false
+
 actual suspend fun getDocExtGroups(query: String): List<Pair<String, Int>> = emptyList()
 
 actual suspend fun searchImagesCombined(


### PR DESCRIPTION
## Summary
- Adds a `moveMediaItems(type, query, destDir)` GraphQL mutation so the web images page can bulk-move selected images into a target folder (companion frontend PR: plainhub/plain-desktop)
- New `moveMedia` expect/actual: Android moves files, scans old/new paths so MediaStore picks up the change; iOS returns false
- `BaseMediaContentHelper.moveByIdsAsync` creates the destination directory if missing, skips files already there, and avoids name collisions via `getNewPath`

## Test plan
- `:shared:assembleAndroidMain` builds successfully
- `:shared:testAndroidHostTest` passes
- Verified on device via the companion web frontend PR

Co-Authored-By: AtomCode (glm5.3-flash) <noreply@atomgit.com>