### PR TITLE
feat: add trashSms/restoreSms mutations for app-side SMS trash

### DIFF
--- a/room-db/schemas/com.ismartcoding.plain.platform.AppDatabase/26.json
+++ b/room-db/schemas/com.ismartcoding.plain.platform.AppDatabase/26.json
@@ -1,0 +1,1389 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 26,
+    "identityHash": "5e13bbcc017fadad43cb980a54434e51",
+    "entities": [
+      {
+        "tableName": "chats",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `from_id` TEXT NOT NULL, `to_id` TEXT NOT NULL, `channel_id` TEXT NOT NULL, `status` TEXT NOT NULL DEFAULT 'PENDING', `status_data` TEXT NOT NULL DEFAULT '', `content` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromId",
+            "columnName": "from_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toId",
+            "columnName": "to_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channel_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'PENDING'"
+          },
+          {
+            "fieldPath": "statusData",
+            "columnName": "status_data",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_chats_from_id",
+            "unique": false,
+            "columnNames": [
+              "from_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chats_from_id` ON `${TABLE_NAME}` (`from_id`)"
+          },
+          {
+            "name": "index_chats_to_id",
+            "unique": false,
+            "columnNames": [
+              "to_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chats_to_id` ON `${TABLE_NAME}` (`to_id`)"
+          },
+          {
+            "name": "index_chats_channel_id",
+            "unique": false,
+            "columnNames": [
+              "channel_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_chats_channel_id` ON `${TABLE_NAME}` (`channel_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`client_id` TEXT NOT NULL, `name` TEXT NOT NULL DEFAULT '', `type` TEXT NOT NULL DEFAULT 'WEB', `client_ip` TEXT NOT NULL, `os_name` TEXT NOT NULL, `os_version` TEXT NOT NULL, `browser_name` TEXT NOT NULL, `browser_version` TEXT NOT NULL, `token` TEXT NOT NULL, `last_active_at` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`client_id`))",
+        "fields": [
+          {
+            "fieldPath": "clientId",
+            "columnName": "client_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'WEB'"
+          },
+          {
+            "fieldPath": "clientIP",
+            "columnName": "client_ip",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "osName",
+            "columnName": "os_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "osVersion",
+            "columnName": "os_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browserName",
+            "columnName": "browser_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browserVersion",
+            "columnName": "browser_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "token",
+            "columnName": "token",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastActiveAt",
+            "columnName": "last_active_at",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "client_id"
+          ]
+        }
+      },
+      {
+        "tableName": "tags",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `type` INTEGER NOT NULL, `count` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "tag_relations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tag_id` TEXT NOT NULL, `key` TEXT NOT NULL, `type` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `size` INTEGER NOT NULL, `title` TEXT NOT NULL, PRIMARY KEY(`tag_id`, `key`, `type`))",
+        "fields": [
+          {
+            "fieldPath": "tagId",
+            "columnName": "tag_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tag_id",
+            "key",
+            "type"
+          ]
+        }
+      },
+      {
+        "tableName": "notes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `deleted_at` TEXT, `content` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deletedAt",
+            "columnName": "deleted_at",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "feeds",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `url` TEXT NOT NULL, `fetch_content` INTEGER NOT NULL, `last_sync_at` TEXT, `last_error` TEXT NOT NULL DEFAULT '', `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fetchContent",
+            "columnName": "fetch_content",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncAt",
+            "columnName": "last_sync_at",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastError",
+            "columnName": "last_error",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feeds_url",
+            "unique": true,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_feeds_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ]
+      },
+      {
+        "tableName": "feed_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `url` TEXT NOT NULL, `image` TEXT NOT NULL, `description` TEXT NOT NULL, `author` TEXT NOT NULL, `content` TEXT NOT NULL, `feed_id` TEXT NOT NULL, `raw_id` TEXT NOT NULL, `published_at` TEXT NOT NULL, `read` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feed_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rawId",
+            "columnName": "raw_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishedAt",
+            "columnName": "published_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "read",
+            "columnName": "read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_entries_feed_id",
+            "unique": false,
+            "columnNames": [
+              "feed_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_entries_feed_id` ON `${TABLE_NAME}` (`feed_id`)"
+          },
+          {
+            "name": "index_feed_entries_raw_id",
+            "unique": false,
+            "columnNames": [
+              "raw_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_entries_raw_id` ON `${TABLE_NAME}` (`raw_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "books",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `author` TEXT NOT NULL, `image` TEXT NOT NULL, `description` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "book_chapters",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `book_id` TEXT NOT NULL, `parent_id` TEXT NOT NULL, `content` TEXT NOT NULL, `display_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "book_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parent_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "content",
+            "columnName": "content",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayOrder",
+            "columnName": "display_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "pomodoro_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` TEXT NOT NULL, `completed_count` INTEGER NOT NULL, `total_work_seconds` INTEGER NOT NULL, `total_break_seconds` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedCount",
+            "columnName": "completed_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalWorkSeconds",
+            "columnName": "total_work_seconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBreakSeconds",
+            "columnName": "total_break_seconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "peers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `ip` TEXT NOT NULL, `key` TEXT NOT NULL, `public_key` TEXT NOT NULL, `status` TEXT NOT NULL, `port` INTEGER NOT NULL, `device_type` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ip",
+            "columnName": "ip",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publicKey",
+            "columnName": "public_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceType",
+            "columnName": "device_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "chat_channels",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `key` TEXT NOT NULL, `owner` TEXT NOT NULL DEFAULT '', `members` TEXT NOT NULL, `version` INTEGER NOT NULL DEFAULT 0, `status` TEXT NOT NULL DEFAULT 'JOINED', `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "owner",
+            "columnName": "owner",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "members",
+            "columnName": "members",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'JOINED'"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `title` TEXT NOT NULL, `favicon_path` TEXT NOT NULL, `group_id` TEXT NOT NULL, `pinned` INTEGER NOT NULL, `click_count` INTEGER NOT NULL, `last_clicked_at` TEXT, `sort_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "faviconPath",
+            "columnName": "favicon_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "group_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pinned",
+            "columnName": "pinned",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clickCount",
+            "columnName": "click_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastClickedAt",
+            "columnName": "last_clicked_at",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_bookmarks_group_id",
+            "unique": false,
+            "columnNames": [
+              "group_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_bookmarks_group_id` ON `${TABLE_NAME}` (`group_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "bookmark_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `collapsed` INTEGER NOT NULL, `sort_order` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collapsed",
+            "columnName": "collapsed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `size` INTEGER NOT NULL, `mime_type` TEXT NOT NULL, `real_path` TEXT NOT NULL, `ref_count` INTEGER NOT NULL, `weak_hash` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mime_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "realPath",
+            "columnName": "real_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "refCount",
+            "columnName": "ref_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "weakHash",
+            "columnName": "weak_hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_files_size_weak_hash",
+            "unique": false,
+            "columnNames": [
+              "size",
+              "weak_hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_files_size_weak_hash` ON `${TABLE_NAME}` (`size`, `weak_hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "image_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `path` TEXT NOT NULL, `embedding` BLOB NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embedding",
+            "columnName": "embedding",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "archived_conversations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`conversation_id` TEXT NOT NULL, `conversation_date` INTEGER NOT NULL, PRIMARY KEY(`conversation_id`))",
+        "fields": [
+          {
+            "fieldPath": "conversationId",
+            "columnName": "conversation_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "conversationDate",
+            "columnName": "conversation_date",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "conversation_id"
+          ]
+        }
+      },
+      {
+        "tableName": "trashed_messages",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`message_id` TEXT NOT NULL, `is_mms` INTEGER NOT NULL, `trashed_at` INTEGER NOT NULL, PRIMARY KEY(`message_id`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "message_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMms",
+            "columnName": "is_mms",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trashedAt",
+            "columnName": "trashed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "message_id"
+          ]
+        }
+      },
+      {
+        "tableName": "video_play_progress",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_id` TEXT NOT NULL, `duration` INTEGER NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`media_id`))",
+        "fields": [
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "media_id"
+          ]
+        }
+      },
+      {
+        "tableName": "image_editor_projects",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `state_b64` TEXT NOT NULL, `thumbnail` TEXT, `canvas_width` INTEGER NOT NULL, `canvas_height` INTEGER NOT NULL, `layer_count` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stateB64",
+            "columnName": "state_b64",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnail",
+            "columnName": "thumbnail",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "canvasWidth",
+            "columnName": "canvas_width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "canvasHeight",
+            "columnName": "canvas_height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "layerCount",
+            "columnName": "layer_count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "media_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`media_type` TEXT NOT NULL, `media_id` TEXT NOT NULL, `duration` INTEGER NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`media_id`))",
+        "fields": [
+          {
+            "fieldPath": "mediaType",
+            "columnName": "media_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaId",
+            "columnName": "media_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "media_id"
+          ]
+        }
+      },
+      {
+        "tableName": "shares",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `password` TEXT NOT NULL, `url_token` TEXT NOT NULL, `expires_at` TEXT, `read_only` INTEGER NOT NULL, `data` TEXT NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "urlToken",
+            "columnName": "url_token",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expires_at",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readOnly",
+            "columnName": "read_only",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "clipboard",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `text` TEXT NOT NULL, `hash` TEXT NOT NULL, `source` TEXT NOT NULL, `label` TEXT NOT NULL, `sensitive` INTEGER NOT NULL, `created_at` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "text",
+            "columnName": "text",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensitive",
+            "columnName": "sensitive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clipboard_hash",
+            "unique": false,
+            "columnNames": [
+              "hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clipboard_hash` ON `${TABLE_NAME}` (`hash`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5e13bbcc017fadad43cb980a54434e51')"
+    ]
+  }
+}

--- a/room-db/src/commonMain/kotlin/com/ismartcoding/plain/db/DTrashedMessage.kt
+++ b/room-db/src/commonMain/kotlin/com/ismartcoding/plain/db/DTrashedMessage.kt
@@ -1,0 +1,35 @@
+package com.ismartcoding.plain.db
+
+import androidx.room3.ColumnInfo
+import androidx.room3.Dao
+import androidx.room3.Entity
+import androidx.room3.Insert
+import androidx.room3.OnConflictStrategy
+import androidx.room3.PrimaryKey
+import androidx.room3.Query
+
+@Entity(tableName = "trashed_messages")
+data class DTrashedMessage(
+    @PrimaryKey
+    @ColumnInfo(name = "message_id")
+    val messageId: String, // sms numeric id, or "mms_<id>" for MMS
+    @ColumnInfo(name = "is_mms")
+    val isMms: Boolean,
+    @ColumnInfo(name = "trashed_at")
+    val trashedAt: Long, // epoch millis; used for the 30-day retention cleanup
+)
+
+@Dao
+interface TrashedMessageDao {
+    @Query("SELECT message_id FROM trashed_messages")
+    suspend fun getAllIds(): List<String>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(items: List<DTrashedMessage>)
+
+    @Query("DELETE FROM trashed_messages WHERE message_id IN (:messageIds)")
+    suspend fun deleteByMessageIds(messageIds: List<String>)
+
+    @Query("DELETE FROM trashed_messages WHERE trashed_at < :beforeMillis")
+    suspend fun deleteOlderThan(beforeMillis: Long)
+}

--- a/room-db/src/commonMain/kotlin/com/ismartcoding/plain/platform/Database.kt
+++ b/room-db/src/commonMain/kotlin/com/ismartcoding/plain/platform/Database.kt
@@ -40,13 +40,14 @@ class ChatsGroupIdToChannelIdSpec : AutoMigrationSpec
         DAppFile::class,
         DImageEmbedding::class,
         DArchivedConversation::class,
+        DTrashedMessage::class,
         DVideoPlayProgress::class,
         DImageEditorProject::class,
         DMediaItem::class,
         DShare::class,
         DClipboard::class,
     ],
-    version = 25,
+    version = 26,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3, spec = BoxesDeletionSpec::class),
@@ -66,6 +67,7 @@ class ChatsGroupIdToChannelIdSpec : AutoMigrationSpec
         AutoMigration(from = 17, to = 18),
         AutoMigration(from = 23, to = 24),
         AutoMigration(from = 24, to = 25),
+        AutoMigration(from = 25, to = 26),
     ],
     exportSchema = true,
 )
@@ -101,6 +103,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun appFileDao(): AppFileDao
     abstract fun imageEmbeddingDao(): ImageEmbeddingDao
     abstract fun archivedConversationDao(): ArchivedConversationDao
+    abstract fun trashedMessageDao(): TrashedMessageDao
     abstract fun videoPlayProgressDao(): VideoPlayProgressDao
     abstract fun imageEditorProjectDao(): ImageEditorProjectDao
     abstract fun mediaItemDao(): MediaItemDao

--- a/shared/apitest/schema.graphqls
+++ b/shared/apitest/schema.graphqls
@@ -93,6 +93,8 @@ type Mutation {
   unarchiveConversation(id: String!): Boolean!
   sendSms(number: String!, body: String!, subscriptionId: Int!, requestId: String): Boolean!
   archiveConversation(id: String!, date: Long!): Boolean!
+  trashSms(query: String!): Boolean!
+  restoreSms(query: String!): Boolean!
   sendMms(number: String!, body: String!, attachmentPaths: [String!]!, threadId: String!): String!
   createTag(type: DataType!, name: String!): Tag
   updateTag(id: ID!, name: String!): Tag

--- a/shared/src/androidMain/kotlin/com/ismartcoding/plain/features/sms/SmsHelper.kt
+++ b/shared/src/androidMain/kotlin/com/ismartcoding/plain/features/sms/SmsHelper.kt
@@ -192,6 +192,7 @@ object SmsHelper {
     private fun buildWhere(
         conditions: List<FilterField>,
         archivedRecords: List<DArchivedConversation>,
+        trashedIds: Set<String> = emptySet(),
     ): ContentWhere {
         val where = ContentWhere()
         conditions.forEach {
@@ -205,6 +206,20 @@ object SmsHelper {
                 "type" -> where.add("${Telephony.Sms.TYPE} = ?", it.value)
                 "thread_id" -> where.add("${Telephony.Sms.THREAD_ID} = ?", it.value)
             }
+        }
+
+        // trashed:1 → only show app-side trashed messages; otherwise exclude them
+        val showTrashed = conditions.any { it.name == "trashed" && it.value == "1" }
+        val smsTrashedIds = trashedIds.filterNot { it.startsWith("mms_") }
+        if (showTrashed) {
+            val predicate = SmsProviderContract.numericIdPredicate(BaseColumns._ID, smsTrashedIds)
+            if (predicate != null) {
+                where.add(predicate)
+            } else {
+                where.add("${BaseColumns._ID} = ?", "-1")
+            }
+        } else {
+            where.addNotIn(BaseColumns._ID, smsTrashedIds)
         }
 
         val threadIdCondition = conditions.firstOrNull { it.name == "thread_id" }
@@ -227,6 +242,7 @@ object SmsHelper {
         conditions: List<FilterField>,
         archivedRecords: List<DArchivedConversation>,
         textMatchedMmsIds: Set<String>? = null,
+        trashedIds: Set<String> = emptySet(),
     ): ContentWhere? {
         val where = ContentWhere()
         if (conditions.any { it.name == "text" }) {
@@ -248,6 +264,20 @@ object SmsHelper {
             }
         }
         where.add(SmsProviderContract.MMS_CONTENT_FILTER)
+
+        // trashed:1 → only show app-side trashed MMS; otherwise exclude them
+        val showTrashed = conditions.any { it.name == "trashed" && it.value == "1" }
+        val mmsTrashedIds = trashedIds.filter { it.startsWith("mms_") }.map { it.removePrefix("mms_") }
+        if (showTrashed) {
+            val predicate = SmsProviderContract.numericIdPredicate(BaseColumns._ID, mmsTrashedIds)
+            if (predicate != null) {
+                where.add(predicate)
+            } else {
+                where.add("${BaseColumns._ID} = ?", "-1")
+            }
+        } else {
+            where.addNotIn(BaseColumns._ID, mmsTrashedIds)
+        }
 
         val threadId = conditions.firstOrNull { it.name == "thread_id" }?.value
         val archivedConversation = archivedRecords.firstOrNull { it.conversationId == threadId }
@@ -286,6 +316,9 @@ object SmsHelper {
         return count
     }
 
+    private suspend fun getTrashedMessageIds(): Set<String> =
+        AppDatabase.instance.trashedMessageDao().getAllIds().toSet()
+
     suspend fun searchAsync(
         context: Context,
         query: String,
@@ -294,12 +327,13 @@ object SmsHelper {
     ): List<DMessage> = withIO {
         val conditions = QueryHelper.parseAsync(query)
         val archivedRecords = AppDatabase.instance.archivedConversationDao().getAll()
+        val trashedIds = getTrashedMessageIds()
         val threadId = conditions.firstOrNull { it.name == "thread_id" }?.value ?: ""
         if (threadId.isNotEmpty()) {
-            return@withIO searchByThreadAsync(context, threadId, conditions, archivedRecords, limit, offset)
+            return@withIO searchByThreadAsync(context, threadId, conditions, archivedRecords, trashedIds, limit, offset)
         }
 
-        val where = buildWhere(conditions, archivedRecords)
+        val where = buildWhere(conditions, archivedRecords, trashedIds)
         val fetchCap = offset + limit
         val textMatchedMmsIds = findMmsIdsMatchingText(
             context,
@@ -312,7 +346,7 @@ object SmsHelper {
             cursorToSmsMessage(cursor, cache)
         } ?: emptyList()
 
-        val mmsItems = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds)?.let { mmsWhere ->
+        val mmsItems = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds, trashedIds)?.let { mmsWhere ->
             context.contentResolver.queryCursor(
                 mmsUri,
                 arrayOf(
@@ -356,17 +390,18 @@ object SmsHelper {
         threadId: String,
         conditions: List<FilterField>,
         archivedRecords: List<DArchivedConversation>,
+        trashedIds: Set<String>,
         limit: Int,
         offset: Int,
     ): List<DMessage> {
         val fetchCap = offset + limit
 
-        val smsWhere = buildWhere(conditions, archivedRecords)
+        val smsWhere = buildWhere(conditions, archivedRecords, trashedIds)
         val textMatchedMmsIds = findMmsIdsMatchingText(
             context,
             conditions.filter { it.name == "text" }.map { it.value },
         )
-        val mmsWhere = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds)
+        val mmsWhere = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds, trashedIds)
 
         // Query SMS and MMS separately — this is reliable across all devices.
         val smsItems = context.contentResolver.queryCursor(
@@ -593,6 +628,7 @@ object SmsHelper {
     suspend fun countAsync(context: Context, query: String): Int = withIO {
         val conditions = QueryHelper.parseAsync(query)
         val archivedRecords = AppDatabase.instance.archivedConversationDao().getAll()
+        val trashedIds = getTrashedMessageIds()
         val threadId = conditions.firstOrNull { it.name == "thread_id" }?.value ?: ""
         val textMatchedMmsIds = findMmsIdsMatchingText(
             context,
@@ -600,15 +636,15 @@ object SmsHelper {
         )
 
         if (threadId.isNotEmpty()) {
-            return@withIO countByThread(context, conditions, archivedRecords, textMatchedMmsIds)
+            return@withIO countByThread(context, conditions, archivedRecords, textMatchedMmsIds, trashedIds)
         }
 
-        val where = buildWhere(conditions, archivedRecords)
+        val where = buildWhere(conditions, archivedRecords, trashedIds)
 
         // Count SMS (date filter for archived conversations applied in buildWhereAsync)
         val smsCount = queryCount(context, smsUri, where.toSelection(), where.args.toTypedArray())
 
-        val mmsCount = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds)?.let { mmsWhere ->
+        val mmsCount = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds, trashedIds)?.let { mmsWhere ->
             queryCount(context, mmsUri, mmsWhere.toSelection(), mmsWhere.args.toTypedArray())
         } ?: 0
 
@@ -620,10 +656,11 @@ object SmsHelper {
         conditions: List<FilterField>,
         archivedRecords: List<DArchivedConversation>,
         textMatchedMmsIds: Set<String>?,
+        trashedIds: Set<String>,
     ): Int {
-        val smsWhere = buildWhere(conditions, archivedRecords)
+        val smsWhere = buildWhere(conditions, archivedRecords, trashedIds)
         val smsCount = queryCount(context, smsUri, smsWhere.toSelection(), smsWhere.args.toTypedArray())
-        val mmsCount = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds)?.let { mmsWhere ->
+        val mmsCount = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds, trashedIds)?.let { mmsWhere ->
             queryCount(context, mmsUri, mmsWhere.toSelection(), mmsWhere.args.toTypedArray())
         } ?: 0
         return smsCount + mmsCount
@@ -632,7 +669,8 @@ object SmsHelper {
     suspend fun getIdsAsync(context: Context, query: String): Set<String> = withIO {
         val conditions = QueryHelper.parseAsync(query)
         val archivedRecords = AppDatabase.instance.archivedConversationDao().getAll()
-        val where = buildWhere(conditions, archivedRecords)
+        val trashedIds = getTrashedMessageIds()
+        val where = buildWhere(conditions, archivedRecords, trashedIds)
         val textMatchedMmsIds = findMmsIdsMatchingText(
             context,
             conditions.filter { it.name == "text" }.map { it.value },
@@ -646,7 +684,7 @@ object SmsHelper {
         )?.map { cursor, cache ->
             cursor.getStringValue(BaseColumns._ID, cache)
         }.orEmpty()
-        val mmsIds = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds)?.let { mmsWhere ->
+        val mmsIds = buildMmsWhere(conditions, archivedRecords, textMatchedMmsIds, trashedIds)?.let { mmsWhere ->
             context.contentResolver.queryCursor(
                 mmsUri,
                 arrayOf(BaseColumns._ID),

--- a/shared/src/androidMain/kotlin/com/ismartcoding/plain/platform/MediaStore.android.kt
+++ b/shared/src/androidMain/kotlin/com/ismartcoding/plain/platform/MediaStore.android.kt
@@ -6,6 +6,7 @@ import com.ismartcoding.plain.appContext
 import com.ismartcoding.plain.audio.AudioMediaStoreHelper
 import com.ismartcoding.plain.data.DImage
 import com.ismartcoding.plain.data.DMediaBucket
+import com.ismartcoding.plain.db.DTrashedMessage
 import com.ismartcoding.plain.db.IData
 import com.ismartcoding.plain.data.TagRelationStub
 import com.ismartcoding.plain.docs.DocMediaStoreHelper
@@ -165,6 +166,31 @@ actual suspend fun moveMedia(dataType: DataType, ids: Set<String>, destDir: Stri
         DataType.VIDEO -> VideoMediaStoreHelper.moveByIdsAsync(appContext, ids, destDir)
         else -> false
     }
+}
+
+private suspend fun getTrashedMessageIds(): Set<String> =
+    AppDatabase.instance.trashedMessageDao().getAllIds().toSet()
+
+actual suspend fun trashSms(query: String): Int {
+    val ids = SmsHelper.getIdsAsync(appContext, query)
+    if (ids.isEmpty()) return 0
+    val dao = AppDatabase.instance.trashedMessageDao()
+    // opportunistically drop shadow entries older than 30 days
+    dao.deleteOlderThan(System.currentTimeMillis() - 30L * 24 * 60 * 60 * 1000)
+    val now = System.currentTimeMillis()
+    val newIds = ids - getTrashedMessageIds()
+    dao.insertAll(newIds.map { DTrashedMessage(messageId = it, isMms = it.startsWith("mms_"), trashedAt = now) })
+    return newIds.size
+}
+
+actual suspend fun restoreSms(query: String): Int {
+    val ids = SmsHelper.getIdsAsync(appContext, query)
+    if (ids.isEmpty()) return 0
+    val dao = AppDatabase.instance.trashedMessageDao()
+    val trashed = getTrashedMessageIds()
+    val restorable = ids.filter { it in trashed }
+    dao.deleteByMessageIds(restorable)
+    return restorable.size
 }
 
 actual suspend fun getDocExtGroups(query: String): List<Pair<String, Int>> =

--- a/shared/src/commonMain/kotlin/com/ismartcoding/plain/helpers/ContentWhere.kt
+++ b/shared/src/commonMain/kotlin/com/ismartcoding/plain/helpers/ContentWhere.kt
@@ -12,6 +12,13 @@ data class ContentWhere(
         }
     }
 
+    fun addNotIn(field: String, values: List<String>) {
+        if (values.isNotEmpty()) {
+            selections.add("$field NOT IN (${CharArray(values.size) { '?' }.joinToString(",")})")
+            args.addAll(values)
+        }
+    }
+
     fun add(selection: String, value: String? = null) {
         selections.add(selection)
         if (value != null) {

--- a/shared/src/commonMain/kotlin/com/ismartcoding/plain/httpserver/mainschemas/SmsGraphQL.kt
+++ b/shared/src/commonMain/kotlin/com/ismartcoding/plain/httpserver/mainschemas/SmsGraphQL.kt
@@ -23,6 +23,8 @@ import com.ismartcoding.plain.platform.enabledAndIsGrantedAsync
 import com.ismartcoding.plain.platform.fileExists
 import com.ismartcoding.plain.platform.getArchivedSmsConversations
 import com.ismartcoding.plain.platform.getSmsAllCounts
+import com.ismartcoding.plain.platform.trashSms as trashSmsInternal
+import com.ismartcoding.plain.platform.restoreSms as restoreSmsInternal
 import com.ismartcoding.plain.platform.getLatestSentMmsId
 import com.ismartcoding.plain.platform.launchDefaultSmsApp
 import com.ismartcoding.plain.platform.mimeTypeFromExtension
@@ -123,6 +125,18 @@ suspend fun archivedConversations(): List<MessageConversation> {
 @GraphQLMutation
 suspend fun archiveConversation(id: String, date: Long): Boolean {
     AppDatabase.instance.archivedConversationDao().insert(DArchivedConversation(conversationId = id, conversationDate = date))
+    return true
+}
+
+@GraphQLMutation
+suspend fun trashSms(query: String): Boolean {
+    trashSmsInternal(query)
+    return true
+}
+
+@GraphQLMutation
+suspend fun restoreSms(query: String): Boolean {
+    restoreSmsInternal(query)
     return true
 }
 

--- a/shared/src/commonMain/kotlin/com/ismartcoding/plain/platform/MediaStore.kt
+++ b/shared/src/commonMain/kotlin/com/ismartcoding/plain/platform/MediaStore.kt
@@ -168,6 +168,19 @@ expect suspend fun getArchivedSmsConversations(): List<com.ismartcoding.plain.fe
 expect suspend fun getSmsAllCounts(): DSmsCounts
 
 /**
+ * App-side trash for SMS/MMS: records message ids in a Room shadow table
+ * without touching the system provider (no permissions required).
+ * Returns the number of messages marked as trashed.
+ */
+expect suspend fun trashSms(query: String): Int
+
+/**
+ * Revert [trashSms] for the messages matching [query].
+ * Returns the number of messages restored.
+ */
+expect suspend fun restoreSms(query: String): Int
+
+/**
  * Send an SMS text message to [number] with body [body].
  * @param subscriptionId SIM subscription id, or null for default.
  * @param clientId web client identity derived from the authenticated request headers.

--- a/shared/src/iosMain/kotlin/com/ismartcoding/plain/platform/MediaStore.ios.kt
+++ b/shared/src/iosMain/kotlin/com/ismartcoding/plain/platform/MediaStore.ios.kt
@@ -85,6 +85,10 @@ actual suspend fun getArchivedSmsConversations(): List<com.ismartcoding.plain.fe
 
 actual suspend fun getSmsAllCounts(): DSmsCounts = DSmsCounts(0, 0, 0, 0)
 
+actual suspend fun trashSms(query: String): Int = 0
+
+actual suspend fun restoreSms(query: String): Int = 0
+
 actual fun sendSmsText(
     number: String,
     body: String,


### PR DESCRIPTION
## Summary

Phase 1 of the SMS management improvements discussed in #362: app-side per-message trash, following the same "app-side flag" philosophy as `DArchivedConversation` — no writes to the system Telephony provider, zero permissions, works on every device.

- New Room shadow table `trashed_messages` (entity + DAO, DB v25→26 auto-migration)
- `trashSms(query)` / `restoreSms(query)` mutations (query syntax reuses the existing `sms` query filters, e.g. `ids:123` or `thread_id:5`)
- SMS/MMS list queries and counts exclude trashed messages; `trashed:1` shows only trashed ones (trash-bin view ready)
- Shadow entries expire after 30 days
- iOS stubs return 0 (no SMS support on iOS)

Naming matches the media side (`trashMediaItems`/`restoreMediaItems`) so the frontend mental model stays consistent, as discussed in #362. `deleteSms` (real provider deletion via Shizuku) will come on top of this later.

Companion frontend PR: plainhub/plain-desktop (keyboard review mode + per-message trash in chat view).

Co-Authored-By: AtomCode (glm5.3-flash) <noreply@atomgit.com>